### PR TITLE
refactor: drop dependency on promise-polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # unreleased
 
 - Upgrade to Typescript 4
+- Drop depenency on `promise-polyfill`
 
 # 0.4.4
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,8 @@
       "name": "@braintree/asset-loader",
       "version": "0.4.4",
       "license": "MIT",
-      "dependencies": {
-        "promise-polyfill": "^8.3.0"
-      },
       "devDependencies": {
         "@types/jest": "^29.4.0",
-        "@types/promise-polyfill": "^6.0.4",
         "@typescript-eslint/eslint-plugin": "^5.54.1",
         "eslint": "^8.35.0",
         "eslint-config-braintree": "^6.0.0-typescript-prep-rc.2",
@@ -1330,12 +1326,6 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
       "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
-      "dev": true
-    },
-    "node_modules/@types/promise-polyfill": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/promise-polyfill/-/promise-polyfill-6.0.4.tgz",
-      "integrity": "sha512-GSCjjH6mDS8jgpT22rEOkZVqZcYj7i9AHJu4ntpvoohEpa0mLAKP/Kz3POMKqABaFsS4TyNHOeoyWpzycddcoQ==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -4694,11 +4684,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/promise-polyfill": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
-      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg=="
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -6635,12 +6620,6 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
       "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
-      "dev": true
-    },
-    "@types/promise-polyfill": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/promise-polyfill/-/promise-polyfill-6.0.4.tgz",
-      "integrity": "sha512-GSCjjH6mDS8jgpT22rEOkZVqZcYj7i9AHJu4ntpvoohEpa0mLAKP/Kz3POMKqABaFsS4TyNHOeoyWpzycddcoQ==",
       "dev": true
     },
     "@types/semver": {
@@ -9074,11 +9053,6 @@
           "dev": true
         }
       }
-    },
-    "promise-polyfill": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
-      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg=="
     },
     "prompts": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "homepage": "https://github.com/braintree/asset-loader#readme",
   "devDependencies": {
     "@types/jest": "^29.4.0",
-    "@types/promise-polyfill": "^6.0.4",
     "@typescript-eslint/eslint-plugin": "^5.54.1",
     "eslint": "^8.35.0",
     "eslint-config-braintree": "^6.0.0-typescript-prep-rc.2",
@@ -40,9 +39,6 @@
     "prettier": "^2.8.4",
     "ts-jest": "^29.0.5",
     "typescript": "^4.9.5"
-  },
-  "dependencies": {
-    "promise-polyfill": "^8.3.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/src/lib/promise.ts
+++ b/src/lib/promise.ts
@@ -1,7 +1,0 @@
-import PromisePolyfill from "promise-polyfill";
-
-const PromiseGlobal =
-  // eslint-disable-next-line no-undef
-  typeof Promise !== "undefined" ? Promise : PromisePolyfill;
-
-export { PromiseGlobal };

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -1,4 +1,3 @@
-import { PromiseGlobal as Promise } from "./lib/promise";
 import { LoadScriptOptions } from "./types";
 
 let scriptPromiseCache = {} as Record<string, Promise<HTMLScriptElement>>;

--- a/src/load-stylesheet.ts
+++ b/src/load-stylesheet.ts
@@ -1,4 +1,3 @@
-import { PromiseGlobal as Promise } from "./lib/promise";
 import { LoadStylesheetOptions } from "./types";
 
 export = function loadStylesheet(


### PR DESCRIPTION
Now that we only support browsers that also support promises natively, we can drop promise-polyfill as a dependency.