### PR TITLE
feat: support script type attribute

### DIFF
--- a/src/__tests__/load-script.ts
+++ b/src/__tests__/load-script.ts
@@ -152,6 +152,16 @@ describe("loadScript", () => {
     });
   });
 
+  it("can pass type attribute", () => {
+    testContext.options.type = "module";
+
+    return loadScript(testContext.options).then(() => {
+      const scriptTag = testContext.fakeContainer.appendChild.mock.calls[0][0];
+
+      expect(scriptTag.setAttribute).toBeCalledWith("type", "module");
+    });
+  });
+
   it("passes additional data-attributes", () => {
     testContext.options.dataAttributes = {
       "log-level": "warn",

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -23,6 +23,10 @@ function loadScript(options: LoadScriptOptions): Promise<HTMLScriptElement> {
   script.id = options.id || "";
   script.async = true;
 
+  if (options.type) {
+    script.setAttribute("type", `${options.type}`);
+  }
+
   if (options.crossorigin) {
     script.setAttribute("crossorigin", `${options.crossorigin}`);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type LoadScriptOptions = {
   dataAttributes?: Record<string, string | number>;
   forceScriptReload?: boolean;
   src: string;
+  type?: string;
   id?: string;
 };
 


### PR DESCRIPTION
Wanted to add support for loading scripts with `type=module` mostly