### PR TITLE
feat: remove promise polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Remove promise polyfill
+
 # 1.0.1
 
 - Dependabot Updates

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@braintree/asset-loader",
       "version": "1.0.1",
       "license": "MIT",
-      "dependencies": {
-        "promise-polyfill": "^8.3.0"
-      },
       "devDependencies": {
         "@types/jest": "^29.5.3",
         "@types/promise-polyfill": "^6.0.4",
@@ -5097,11 +5094,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/promise-polyfill": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
-      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg=="
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -9774,11 +9766,6 @@
           "dev": true
         }
       }
-    },
-    "promise-polyfill": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
-      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg=="
     },
     "prompts": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "promise-polyfill": "^8.3.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/src/lib/promise.ts
+++ b/src/lib/promise.ts
@@ -1,7 +1,0 @@
-import PromisePolyfill from "promise-polyfill";
-
-const PromiseGlobal =
-  // eslint-disable-next-line no-undef
-  typeof Promise !== "undefined" ? Promise : PromisePolyfill;
-
-export { PromiseGlobal };

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -1,4 +1,3 @@
-import { PromiseGlobal as Promise } from "./lib/promise";
 import { LoadScriptOptions } from "./types";
 
 let scriptPromiseCache = {} as Record<string, Promise<HTMLScriptElement>>;

--- a/src/load-stylesheet.ts
+++ b/src/load-stylesheet.ts
@@ -1,4 +1,3 @@
-import { PromiseGlobal as Promise } from "./lib/promise";
 import { LoadStylesheetOptions } from "./types";
 
 export = function loadStylesheet(


### PR DESCRIPTION
This will drop the promise polyfill from this library. That means browsers without native promise support will have issues using this library.