### PR TITLE
Add ability to set script integrity attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Add ability to set script `integrity` attribute
+
 ## 2.0.2
 
 - Updates dev dependencies

--- a/src/__tests__/load-script.ts
+++ b/src/__tests__/load-script.ts
@@ -162,6 +162,19 @@ describe("loadScript", () => {
     });
   });
 
+  it("can pass integrity attribute", () => {
+    testContext.options.integrity = "some-integrity-hash";
+
+    return loadScript(testContext.options).then(() => {
+      const scriptTag = testContext.fakeContainer.appendChild.mock.calls[0][0];
+
+      expect(scriptTag.setAttribute).toBeCalledWith(
+        "integrity",
+        "some-integrity-hash",
+      );
+    });
+  });
+
   it("passes additional data-attributes", () => {
     testContext.options.dataAttributes = {
       "log-level": "warn",

--- a/src/load-script.ts
+++ b/src/load-script.ts
@@ -30,6 +30,10 @@ function loadScript(options: LoadScriptOptions): Promise<HTMLScriptElement> {
     script.setAttribute("crossorigin", `${options.crossorigin}`);
   }
 
+  if (options.integrity) {
+    script.setAttribute("integrity", `${options.integrity}`);
+  }
+
   Object.keys(attrs).forEach(function (key) {
     script.setAttribute(`data-${key}`, `${attrs[key]}`);
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export type LoadScriptOptions = {
   crossorigin?: boolean | string;
   dataAttributes?: Record<string, string | number>;
   forceScriptReload?: boolean;
+  integrity?: string;
   src: string;
   type?: string;
   id?: string;


### PR DESCRIPTION
Add ability to set script `integrity` attribute

MDN for `integrity` attribute: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity