### PR TITLE
ci: add pull_request, workflow_call, and workflow_dispatch triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,14 @@
 name: "Unit Tests"
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
# Summary of changes

- Add `pull_request` trigger so CI runs on PRs before merge, ensuring unit tests are a verified quality gate
- Scope `push` trigger to `main` only to avoid double-running CI on PR branches
- Add `workflow_call` and `workflow_dispatch` to align with the established team standard (framebus, uuid, event-emitter, restricted-input)

Part of DTBTWEB-1295 / DTBTWEB-1282 (Quality Maturity Framework Level 3 compliance).

## Checklist

- [ ] Added a changelog entry
- [ ] Relevant test coverage
- [ ] Tested and confirmed flows affected by this change are functioning as expected

## Authors

- @lvandenboom

### Reviewers

@braintree/team-sdk-js