### PR TITLE
(build) create dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 3
+    allow:
+      - dependency-type: "development"
+        update-types:
+          - "version-update:semver-minor"
     groups:
       security-updates:
         applies-to: security-updates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,10 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
   pull_request:
     branches:
       - "*"
-  workflow_call:
-  workflow_dispatch:
 
 jobs:
   build:
@@ -16,10 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
-          node-version: "18.x"
-      - run: npm install
+          node-version-file: .nvmrc
+      - run: npm ci
+      - run: npx eslint . --ext .js,.ts
       - run: npm test


### PR DESCRIPTION
# Summary of changes

- create a dependabot config that makes it less noisy, hopefully.
  - can now only have 3 prs open in a repo
  - only run once a week, and should bundle updates
  - only upgrades dev dependencies for minor, not patches

## Checklist

- [ ] Added a changelog entry <-- skipped
- [ ] Relevant test coverage <-- skipped
- [ ] Tested and confirmed flows affected by this change are functioning as expected <-- skipped

## Authors

> List GitHub usernames for everyone who contributed to this pull request.

@adrmachado-public 

### Reviewers

@braintree/team-sdk-js
